### PR TITLE
added nodemon that was missing from npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "browser-sync": "^2.1.6",
     "browserify": "^8.0.3",
     "eslint": "^0.14.1",
+    "nodemon": "^1.3.7",
     "rework": "^1.0.1",
     "rework-npm": "^1.0.0",
     "rework-npm-cli": "^0.1.1",


### PR DESCRIPTION
This helps out the series of warnings message that comes up when nodemon is not present. 