### PR TITLE
Added missing dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babelify": "^6.0.2",
     "browser-sync": "^2.1.6",
     "browserify": "^8.0.3",
+    "clean-css": "^3.3.5",
     "eslint": "^0.14.1",
     "nodemon": "^1.3.7",
     "rework": "^1.0.1",


### PR DESCRIPTION
clean-css was missing, which was causing npm start and other npm scripts to fail